### PR TITLE
entrypoint.sh: Replace the usage of `set-output` command

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -85,8 +85,8 @@ elif [[ -n ${FILES_CHANGED} ]]; then
 fi
 
 # Finish
-echo "::set-output name=files_changed::${FILES_CHANGED}"
-echo "::set-output name=branch_name::${BRANCH}"
+echo "files_changed=${FILES_CHANGED}" >>"$GITHUB_OUTPUT"
+echo "branch_name=${BRANCH}" >>"$GITHUB_OUTPUT"
 if [[ ${RET_CODE} != "0" ]]; then
   echo -e "\n[ERROR] Check log for errors."
   exit 1


### PR DESCRIPTION
## :memo:  Brief description

Replaces the deprecated use of `::set-output` command with newer flow.

as suggested on github blog: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

## :computer:  Commits
[Fixed the usage of deprecated set-output command in entrypoint script](https://github.com/devops-infra/action-commit-push/commit/5ffb28c537f5bb417c3c7134967d03366821a44d)

## :file_folder:  Modified files
[entrypoint.sh](https://github.com/devops-infra/action-commit-push/compare/master...hjpotter92:action-commit-push:master#diff-6f9d41d046756f0ddc2fcee0626bdb50100d12b88f293734eff742818e03efa2)

## :warning: Additional information
* [x] Pushed to a branch with a proper name and provided proper commit message.
* [x] Provided a clear and concise description of what the issue is.