### PR TITLE
Added support for Git's cleanup mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Features:
 * Can add a custom prefix to commit message title by setting `commit_prefix`.
 * As a commit message title will use `commit_message` if set, or `commit_prefix` and add changed files or just list of changed files.
 * Can create a new branch when `target_branch` is set.
-* Can add a timestamp to a branch name (great for cron-based updates): 
-  * When `target_branch` is set and `add_timestamp` is `true` will create a branch named `${branch_name}/${add_timestamp}`. 
+* Can add a timestamp to a branch name (great for cron-based updates):
+  * When `target_branch` is set and `add_timestamp` is `true` will create a branch named `${branch_name}/${add_timestamp}`.
   * When `target_branch` is not set and `add_timestamp` is `true` will create a branch named `${add_timestamp}`.
 * Good to combine with my other action [devops-infra/action-pull-request](https://github.com/devops-infra/action-pull-request).
 * Can use `git push --force` for fast-forward changes with `force` input.
@@ -44,6 +44,7 @@ Features:
         add_timestamp: true
         commit_prefix: "[AUTO]"
         commit_message: "Automatic commit"
+        message_cleanup: "default"
         force: false
         target_branch: update/version
 ```
@@ -56,6 +57,7 @@ Features:
 | amend               | No       | `false`          | Whether to make amendment to the previous commit (`--amend`). Cannot be used together with `commit_message` or `commit_prefix`.                                    |
 | commit_prefix       | No       | `""`             | Prefix added to commit message. Combines with `commit_message`.                                                                                                    |
 | commit_message      | No       | `""`             | Commit message to set. Combines with `commit_prefix`. Cannot be used together with `amend`.                                                                        |
+| message_cleanup     | No       | `"default"`      | This option determines how the supplied commit message should be cleaned up before committing. Can be `strip`, `whitespace`, `verbatim`, `scissors` or `default`. See [git documentation](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---cleanupltmodegt) |
 | force               | No       | `false`          | Whether to use force push for fast-forward changes (`--force`). Use only if necessary, e.g. when using `--amend`. And set `fetch-depth: 0` for `actions/checkout`. |
 | no_edit             | No       | `false`          | Whether to not edit commit message when using amend (`--no-edit`).                                                                                                 |
 | organization_domain | No       | `github.com`     | Github Enterprise domain name.                                                                                                                                     |

--- a/action.yml
+++ b/action.yml
@@ -38,6 +38,11 @@ inputs:
     description: Name of a new branch to push the code into
     required: false
     default: ""
+  message_cleanup:
+    # https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---cleanupltmodegt
+    description: 'Determines how the supplied commit message should be cleaned up before committing'
+    required: false
+    default: default
 outputs:
   files_changed:
     description: List of changed files

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,6 +10,7 @@ echo "  add_timestamp:       ${INPUT_ADD_TIMESTAMP}"
 echo "  amend:               ${INPUT_AMEND}"
 echo "  commit_prefix:       ${INPUT_COMMIT_PREFIX}"
 echo "  commit_message:      ${INPUT_COMMIT_MESSAGE}"
+echo "  message_cleanup:     ${INPUT_MESSAGE_CLEANUP}"
 echo "  force:               ${INPUT_FORCE}"
 echo "  no_edit:             ${INPUT_NO_EDIT}"
 echo "  organization_domain: ${INPUT_ORGANIZATION_DOMAIN}"
@@ -29,6 +30,7 @@ git config --global safe.directory /github/workspace
 git remote set-url origin "https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@${INPUT_ORGANIZATION_DOMAIN}/${GITHUB_REPOSITORY}"
 git config --global user.name "${GITHUB_ACTOR}"
 git config --global user.email "${GITHUB_ACTOR}@users.noreply.${INPUT_ORGANIZATION_DOMAIN}"
+git config --global commit.cleanup "${INPUT_MESSAGE_CLEANUP}"
 
 # Get changed files
 git add -A


### PR DESCRIPTION
## :memo:  What
Adding support to explicitly set the cleanup mode for commit messages:
- [Git documentation](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---cleanupltmodegt)

# Why
Supporting alternative cleanup modes means that you can:
- use `verbatim` to include a markdown table in your message
- use `scissors` to include markdown headers in your message

Without this support the default cleanup mode will strip information from your commit message. This can have a negative impact when relying on the commit message to be used as the GitHub description:
- markdown tables are interpreted as a single long line (even when a trailing double space is provided to break the line)
- lines leading with `#` are interpreted as a comment

## :warning: Additional information

* [x] Pushed to a branch with a proper name and provided proper commit message.
* [x] Provided a clear and concise description of what the issue is.

*Check [CONTRIBUTING.md][contributing] and [CODE_OF_CONDUCT.md][code] for more information*

[contributing]: https://github.com/devops-infra/.github/blob/master/CONTRIBUTING.md
[code]: https://github.com/devops-infra/.github/blob/master/CODE_OF_CONDUCT.md
